### PR TITLE
added tommi.space

### DIFF
--- a/_site_listings/tommi.space.md
+++ b/_site_listings/tommi.space.md
@@ -1,0 +1,4 @@
+---
+pageurl: tommi.space
+size: 667.1
+---

--- a/_site_listings/tommi.space.md
+++ b/_site_listings/tommi.space.md
@@ -1,4 +1,4 @@
 ---
-pageurl: tommi.space
+pageurl: tommi.space/home
 size: 667.1
 ---


### PR DESCRIPTION
Actually, the size of the site’s landing page is less, but the actual size is the size of the [homepage](https://tools.pingdom.com/#5e69044acac00000 'results for tommi.space/tuffo')