### PR TITLE
Update tutor.0b.ee size

### DIFF
--- a/_site_listings/tutor.0b.ee.md
+++ b/_site_listings/tutor.0b.ee.md
@@ -1,4 +1,4 @@
 ---
 pageurl: tutor.0b.ee
-size: 2.3
+size: 1.8
 ---


### PR DESCRIPTION
Some optimizations from a while ago and changes to the AWS settings made the site even smaller. 
AWS API Gateway apparently now also does http to https upgrades so cloudfront is no longer needed saving on http headers.
https://tools.pingdom.com/#5eb8ab2580000000