### PR TITLE
Json API App addition

### DIFF
--- a/_site_listings/jsonapi.co.md
+++ b/_site_listings/jsonapi.co.md
@@ -1,0 +1,4 @@
+---
+pageurl: jsonapi.co
+size: 531
+---

--- a/_site_listings/jsonapi.co.md
+++ b/_site_listings/jsonapi.co.md
@@ -1,4 +1,4 @@
 ---
 pageurl: jsonapi.co
-size: 531
+size: 201.9
 ---


### PR DESCRIPTION
## Add Json API App

Add [jsonapi.co](https://www.jsonapi.co) website which has an uncompressed size of 531KB as per the GTMetrix score: https://gtmetrix.com/reports/www.jsonapi.co/MSMmZ896/

tools.pingdom.com was not responding/working. Tried multiple times. Therefore GTMetrix score is shared.

