### PR TITLE
Updated na20a.neocities.org size

### DIFF
--- a/_site_listings/na20a.neocities.org.md
+++ b/_site_listings/na20a.neocities.org.md
@@ -1,4 +1,4 @@
 ---
 pageurl: na20a.neocities.org
-size: 26.3
+size: 9.8
 ---


### PR DESCRIPTION
Switching to SVG files made the website less than half as big.