### PR TITLE
Remove jonathanbuchh.org.md

### DIFF
--- a/_site_listings/jonathanbuchh.org.md
+++ b/_site_listings/jonathanbuchh.org.md
@@ -1,4 +1,0 @@
----
-pageurl: jonathanbuchh.org
-size: 7.7
----


### PR DESCRIPTION
It is just a redirect of buchh.org, which was recently added.