### PR TITLE
Add slc.is

### DIFF
--- a/_site_listings/slc.is.md
+++ b/_site_listings/slc.is.md
@@ -1,4 +1,4 @@
 ---
 pageurl: slc.is
-size: 344
+size: 437.0
 ---

--- a/_site_listings/slc.is.md
+++ b/_site_listings/slc.is.md
@@ -1,0 +1,4 @@
+---
+pageurl: slc.is
+size: 344
+---


### PR DESCRIPTION
The initial load of the site is slightly heavy since I use [Marked.js](https://github.com/markedjs/marked), [KaTeX](https://github.com/KaTeX/KaTeX), and [Highlight.js](https://github.com/highlightjs/highlight.js); however, once the first page loads, each additional page simply loads an image and a markdown file. The total average page-load across the site is only 7.1 Kb yet it supports markdown, math, and code highlighting. You can look at the [GitHub repo](https://github.com/splch/slc.is/) to confirm.

The total size I included is for the first-load visiting every tab and one blog post (since that's the average).

Edit: Used decompressed sizes