### PR TITLE
fix: Atom and RSS feeds are different

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 <footer>
     <p>A small side-project by <a href="https://uglyduck.ca">Bradley Taunt</a><br>
     Maintained with &hearts; for a performant web<br>
-    Get latest sites via <a href="/atom.xml">RSS</a></p>
+    Get latest sites via <a href="/atom.xml">Atom</a></p>
 </footer>


### PR DESCRIPTION
The feed on this page is indeed using Atom syndication

while as RSS is another different type of format, this could give RSS feed reader confusion.