### PR TITLE
Add runyourown.social

### DIFF
--- a/_site_listings/runyourown.social.md
+++ b/_site_listings/runyourown.social.md
@@ -1,0 +1,4 @@
+---
+pageurl: runyourown.social
+size: 960.0
+---


### PR DESCRIPTION
[Run Your Own Social](https://runyourown.social) is a widely-cited site that runs people through the basics of running a small social network site for their friends. It is 960kb, mostly due to images.