### PR TITLE
update cleberg.io size

### DIFF
--- a/_site_listings/cleberg.io.md
+++ b/_site_listings/cleberg.io.md
@@ -1,4 +1,4 @@
 ---
 pageurl: cleberg.io
-size: 31.0
+size: 7.7
 ---


### PR DESCRIPTION
The new size of cleberg.io (as of 2022-05-26) is `7.7KB`.

Pingdom tools report: https://tools.pingdom.com/#6040bd5a14800000