### PR TITLE
Add fennel-lang.org

### DIFF
--- a/_site_listings/fennel-lang.org.md
+++ b/_site_listings/fennel-lang.org.md
@@ -1,0 +1,4 @@
+---
+pageurl: fennel-lang.org
+size: 638.3
+---


### PR DESCRIPTION
This commit adds <https://fennel-lang.org> to the list, which is currently at 638KiB :)

@technomancy is the chief maintainer of the site.