### PR TITLE
papojari.codeberg.page → annaaurora.eu

### DIFF
--- a/_site_listings/annaaurora.eu.md
+++ b/_site_listings/annaaurora.eu.md
@@ -1,0 +1,4 @@
+---
+pageurl: annaaurora.eu
+size: 12.9
+---

--- a/_site_listings/papojari.codeberg.page.md
+++ b/_site_listings/papojari.codeberg.page.md
@@ -1,4 +1,0 @@
----
-pageurl: papojari.codeberg.page
-size: 15.4
----


### PR DESCRIPTION
I use the name *Anna Aurora* now and bought a domain for that aswell. The `papojari.codeberg.page` site now exists at `annaaurora.eu`.