### PR TITLE
Add kanji.club

### DIFF
--- a/_site_listings/kanji.club.md
+++ b/_site_listings/kanji.club.md
@@ -1,0 +1,4 @@
+---
+pageurl: kanji.club
+size: 453.7
+---


### PR DESCRIPTION
[Kanji Club](https://kanji.club) is a static website to search Chinese characters based on the parts they're made of. The site has an index of roughly 20k characters that fits in a tiny javascript file via compression, and works offline, since all search happens in the browser. The site is in Japanese.

As an example, [this URL](https://kanji.club/?q=魚) shows all characters that contain 魚, the character for fish.