### PR TITLE
Add dampfkraft.com

### DIFF
--- a/_site_listings/dampfkraft.com.md
+++ b/_site_listings/dampfkraft.com.md
@@ -1,0 +1,4 @@
+---
+pageurl: dampfkraft.com
+size: 39.9
+---


### PR DESCRIPTION
[Dampfkraft](https://dampfkraft.com) is my personal homepage. 

Individual article pages sometimes have large images, which may occasionally make them over 1MB, but the top page is small.