### PR TITLE
change of address matthewthom.as

### DIFF
--- a/_site_listings/matthewthom.as.md
+++ b/_site_listings/matthewthom.as.md
@@ -1,0 +1,4 @@
+---
+pageurl: www.matthewthom.as
+size: 60.6
+---

--- a/_site_listings/matthewthom.as.md
+++ b/_site_listings/matthewthom.as.md
@@ -1,4 +1,4 @@
 ---
-pageurl: www.matthewthom.as
+pageurl: matthewthom.as
 size: 60.6
 ---

--- a/_site_listings/mattwthomas.com.md
+++ b/_site_listings/mattwthomas.com.md
@@ -1,4 +1,0 @@
----
-pageurl: mattwthomas.com
-size: 74.9
----


### PR DESCRIPTION
I finally got this new domain. This changes mattwthomas.com to matthewthom.as. I have a 301 redirect from the old domain.

https://gtmetrix.com/reports/www.matthewthom.as/UshNfnVP/