### PR TITLE
add blakehawkins.com

### DIFF
--- a/_site_listings/blakehawkins.com.md
+++ b/_site_listings/blakehawkins.com.md
@@ -1,0 +1,4 @@
+---
+pageurl: blakehawkins.com/blog
+size: 74.5
+---


### PR DESCRIPTION
Using /blog path because main page just says "intentionally left blank"

([One of the blog posts](https://blakehawkins.com/blog/4) is about how the website is architected for low size)