### PR TITLE
Update paritybit.ca page size

### DIFF
--- a/_site_listings/paritybit.ca.md
+++ b/_site_listings/paritybit.ca.md
@@ -1,4 +1,4 @@
 ---
 pageurl: paritybit.ca
-size: 11.8
+size: 5.1
 ---


### PR DESCRIPTION
The page size has changed significantly since first being listed on 1mbclub.com. This change updates it to the new value:

https://tools.pingdom.com/#60c3982e61400000